### PR TITLE
Fix displaying the water level as a graph rather then strings

### DIFF
--- a/plwf105/plwf105.yaml
+++ b/plwf105/plwf105.yaml
@@ -139,6 +139,9 @@ sensor:
     name: Water Level
     id: water_level_percentage
     update_interval: 1s
+    state_class: measurement
+    unit_of_measurement: '%'
+    accuracy_decimals: 1
     lambda: |-
         if(id(water_level).state >= id(max_water_level)) {
           return 0;


### PR DESCRIPTION
Per https://github.com/taylorfinnell/petlibro-esphome/issues/7 adding a PR to display the water level in a graph-able format