### PR TITLE
plwf105: remove web server

### DIFF
--- a/plwf105/plwf105.yaml
+++ b/plwf105/plwf105.yaml
@@ -153,8 +153,6 @@ sensor:
         
         return ((id(water_level).state - id(min_water_level)) * 100) / (id(max_water_level) - id(min_water_level));
 
-web_server:
-  
 switch:
   - platform: gpio
     name: 'Pump'


### PR DESCRIPTION
Web server is not a fundamental functionality, can be added at will in the main config. It does pose some safety concern as well, as anyone with IP can turn the pump off. It is also resource-heavy.