### PR TITLE
plwf105: remove improv component

### DIFF
--- a/plwf105/plwf105.yaml
+++ b/plwf105/plwf105.yaml
@@ -52,9 +52,6 @@ wifi:
 
 captive_portal:
 
-esp32_improv:
-  authorizer: none
-
 globals:
   - id: max_water_level
     type: int


### PR DESCRIPTION
Correct me if I am wrong, but it seems improv component is not configured at all and of little use in our case, since a manual binary upload is required after all, so it gets flashed with WiFi preconfigured.